### PR TITLE
Добавил контроль индекса SubString

### DIFF
--- a/SystemClasses/String.cpp
+++ b/SystemClasses/String.cpp
@@ -107,7 +107,7 @@ String String::Replace(const String &sub, const String &replace) const
 
 String String::SubString(int StartIndex, int Count) const
 {
-	if (StartIndex > Length()) {
+	if (StartIndex > Length() || StartIndex <= 0) {
 		return String("");
 	}
 	return String(substr(StartIndex - 1, Count));


### PR DESCRIPTION
При вызове из этой строки 	
`|| name.SubString(name.GetLength() - 6, 7).CompareIC("STORAGE") == 0`

Входные параметры SubString
`name = " _NODE7"     name.GetLength() - 6 = 0`
`name = "_Node8"       name.GetLength() - 6 = 0`
`name = "_BPr9"          name.GetLength() - 6 = -1`