### PR TITLE
Добавлена обработка кода возврата при распаковке

### DIFF
--- a/src/ctool1cd/UZLib.cpp
+++ b/src/ctool1cd/UZLib.cpp
@@ -158,8 +158,9 @@ void ZInflateStream(TStream* src, TStream* dst)
 				ret = Z_DATA_ERROR;     /* and fall through */
 			case Z_DATA_ERROR:
 			case Z_MEM_ERROR:
+			case Z_STREAM_ERROR:
 				(void)inflateEnd(&strm);
-				//return ret;
+				return;
 			}
 
 			have = CHUNKSIZE - strm.avail_out;


### PR DESCRIPTION
При распаковке возвращался код -2, который не обрабатывался и соотвествует Z_STREAM_ERROR

При ошибке не проиходило выхода из функции и получался бесконечный цикл.